### PR TITLE
AB#30155:  version endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,21 @@ PUT Body (optional):
     - `GET`
     - `/api/charts/upload`
     
-+ helm version --template='version: {{.Version}} go_version: {{.GoVersion}}'
++ helm version
     - `GET`
     - `/api/version`
+
+Response Body: 
+
+```json
+{
+"code": 0,
+    "data": {
+        "version": "v3.6",
+        "go_version": "go1.17.7"
+    }
+}
+```
 
 > __Notes:__ helm-wrapper is Alpha status, no more test
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ PUT Body (optional):
 + list local charts
     - `GET`
     - `/api/charts/upload`
+    
++ helm version --template='version: {{.Version}} go_version: {{.GoVersion}}'
+    - `GET`
+    - `/api/version`
 
 > __Notes:__ helm-wrapper is Alpha status, no more test
 

--- a/router.go
+++ b/router.go
@@ -30,6 +30,12 @@ func respOK(c *gin.Context, data interface{}) {
 }
 
 func RegisterRouter(router *gin.Engine) {
+	// helm version
+	version := router.Group("/api/version")
+	{
+		version.GET("", getHelmVersion)
+	}
+
 	// helm env
 	envs := router.Group("/api/envs")
 	{

--- a/version.go
+++ b/version.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"github.com/gin-gonic/gin"
+	"helm.sh/helm/v3/pkg/chartutil"
+)
+
+func getHelmVersion(c *gin.Context) {
+	respOK(c, chartutil.DefaultCapabilities)
+}

--- a/version.go
+++ b/version.go
@@ -6,5 +6,5 @@ import (
 )
 
 func getHelmVersion(c *gin.Context) {
-	respOK(c, chartutil.DefaultCapabilities)
+	respOK(c, chartutil.DefaultCapabilities.HelmVersion)
 }


### PR DESCRIPTION
can be refactored to only return the helm semver (this implementation returns helm version, git commit sha, git tree state and go version IF they are set). Current response from this new endpoint:
```
{
	"code": 0,
	"data": {
		"version": "v3.6",
		"go_version": "go1.17.7"
	}
}
```